### PR TITLE
make_boot_descriptor: add no padding when firmware image is aligned

### DIFF
--- a/tools/make_boot_descriptor.py
+++ b/tools/make_boot_descriptor.py
@@ -186,9 +186,9 @@ class FirmwareImage(object):
             self._contents.seek(0, os.SEEK_END)
             self._length = self._contents.tell()
             if self._padding:
-                fill = self._padding - (self._length % self._padding)
-                self._length += fill
-                self._padding = fill
+                mod = self._length % self._padding
+                self._padding = self._padding - mod if mod else 0
+                self._length += self._padding
             self._contents.seek(prev_offset)
 
         return self._length


### PR DESCRIPTION
Hi,

This change stops `make_boot_descriptor.py` from adding any padding to the firmware image if the firmware image is already aligned to the 8 byte boundaries used when calculating the CRC. Currently in this case, `make_boot_descriptor.py` will append 8 `0xFF` bytes to the end of the firmware image.

The motivation for this change is that when I flash firmware directly to a device using [st-util](https://github.com/texane/stlink), any extra space left in the last flash sector is filled with `0x00` rather than being left as `0xFF`. This breaks the assumption used in `make_boot_descriptor.py` causing CRC mismatches. This change fixes this issue as I can then add the requist padding to the end of the firmware image in its linker script.

James.